### PR TITLE
Fix typo in comments for Elixir's Wine Cellar

### DIFF
--- a/analyzer-comments/elixir/wine-cellar/use_keyword_get_values.md
+++ b/analyzer-comments/elixir/wine-cellar/use_keyword_get_values.md
@@ -1,5 +1,5 @@
 # Use `Keyword.get_values`
 
 Keyword lists can contain more than one value for a key, which makes retrieving all values of a key cumbersome.
-`Keyword` module, besides `Keyword.get` to get a single value, also provides `Keyword_get_values` to get multiple values.
+`Keyword` module, besides `Keyword.get` to get a single value, also provides `Keyword.get_values` to get multiple values.
 Use `Keyword.get_values` to filter wines by color.


### PR DESCRIPTION
Replaces a `_` with a `.` to separate module and function name.